### PR TITLE
support short bitcoin cash address format in toOutputScript

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -88,6 +88,14 @@ function toOutputScript (address, network, useNewCashAddress) {
 
     }
 
+    try {
+      decode = fromCashAddress(network.cashAddrPrefix + ':' + address)
+      if (decode.version === 'pubkeyhash') return bscript.pubKeyHash.output.encode(decode.hash)
+      if (decode.version === 'scripthash') return bscript.scriptHash.output.encode(decode.hash)
+    } catch (e) {
+
+    }
+
     if (decode) {
       if (decode.prefix !== network.cashAddrPrefix) throw new Error(address + ' has an invalid prefix')
     }

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -192,7 +192,7 @@
       },
       {
         "exception": "has no matching Address",
-        "script": "OP_TRUE 032487c2a32f7c8d57d2a93906a6457afd00697925b0e6e145d89af6d3bca33016 02308673d16987eaa010e540901cc6fe3695e758c19f46ce604e174dac315e685a OP_2 OP_CHECKMULTISIG"
+        "script": "OP_1 032487c2a32f7c8d57d2a93906a6457afd00697925b0e6e145d89af6d3bca33016 02308673d16987eaa010e540901cc6fe3695e758c19f46ce604e174dac315e685a OP_2 OP_CHECKMULTISIG"
       },
       {
         "exception": "has no matching Address",


### PR DESCRIPTION
should try again with the networks prefix so address decoding can succeed